### PR TITLE
Default to sonoff basic r3 with esp8285

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,11 +1,10 @@
 [platformio]
-env_default = debug
+default_envs = debug
 libdeps_dir = lib
 
 [env:debug]
-platform = https://github.com/taubel/platform-espressif8266.git
-;board = nodemcuv2
-board = esp01_1m
+platform = espressif8266
+board = esp8285
 framework = arduino
 
 build_flags = -Iinclude/ 
@@ -23,11 +22,11 @@ build_flags = -Iinclude/
 
 lib_deps = ArduinoJson
 
-board_flash_mode = dout
+board_build._flash_mode = dout
 
 [env:common]
-platform = https://github.com/taubel/platform-espressif8266.git
-board = esp01_1m
+platform = espressif8266
+board = esp8285
 framework = arduino
 
 build_flags = -Iinclude/
@@ -41,4 +40,4 @@ build_flags = -Iinclude/
      -Wno-pointer-arith
      -DLWM2M_WITH_DTLS=0
 
-board_flash_mode = dout
+board_build._flash_mode = dout


### PR DESCRIPTION
Newest revision sonoff basic uses esp8285 chip. Default to this configuration in master